### PR TITLE
BRAV-933: Tinymce upgrade to 5.4.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce-dist": "~4.2.4"
+    "tinymce-dist": "~4.7.12"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce-dist": "~4.7.12"
+    "tinymce-dist": "~5.4.2"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "angular": "~1.x",
-    "tinymce-dist": "~4.1.10"
+    "tinymce-dist": "~4.2.4"
   },
   "devDependencies": {
     "angular-mocks": "~1.x"


### PR DESCRIPTION
JIRA Ticket: https://aprigo.jira.com/browse/BRAV-933

Reason for change: Tinymce version upgrade for FED compliance